### PR TITLE
Backports fix for #1449

### DIFF
--- a/lib/Server.js
+++ b/lib/Server.js
@@ -19,6 +19,7 @@ const historyApiFallback = require('connect-history-api-fallback');
 const selfsigned = require('selfsigned');
 const sockjs = require('sockjs');
 const spdy = require('spdy');
+const https = require('https');
 const webpack = require('webpack');
 const webpackDevMiddleware = require('webpack-dev-middleware');
 const OptionsValidationError = require('./OptionsValidationError');
@@ -481,7 +482,20 @@ function Server(compiler, options) {
       };
     }
 
-    this.listeningApp = spdy.createServer(options.https, app);
+    // `spdy` is effectively unmaintained, and as a consequence of an
+    // implementation that extensively relies on Node’s non-public APIs, broken
+    // on Node 10 and above. In those cases, only https will be used for now.
+    // Once express supports Node's built-in HTTP/2 support, migrating over to
+    // that should be the best way to go.
+    // The relevant issues are:
+    // - https://github.com/nodejs/node/issues/21665
+    // - https://github.com/webpack/webpack-dev-server/issues/1449
+    // - https://github.com/expressjs/express/issues/3388
+    if (+process.version.match(/^v(\d+)/)[1] >= 10) {
+      this.listeningApp = https.createServer(options.https, app);
+    } else {
+      this.listeningApp = spdy.createServer(options.https, app);
+    }
   } else {
     this.listeningApp = http.createServer(app);
   }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
-  "name": "webpack-dev-server",
-  "version": "2.11.3",
+  "name": "@reverbdotcom/webpack-dev-server",
+  "version": "2.11.3-node10-1",
   "description": "Serves a webpack app. Updates the browser on changes.",
   "license": "MIT",
   "repository": "webpack/webpack-dev-server",

--- a/test/Https.test.js
+++ b/test/Https.test.js
@@ -1,0 +1,33 @@
+'use strict';
+
+const path = require('path');
+const request = require('supertest');
+const helper = require('./helper');
+const config = require('./fixtures/contentbase-config/webpack.config');
+require('mocha-sinon');
+
+const contentBasePublic = path.join(__dirname, 'fixtures/contentbase-config/public');
+
+describe('HTTPS', function testHttps() {
+  let server;
+  let req;
+  afterEach(helper.close);
+
+  // Increase the timeout to 20 seconds to allow time for key generation.
+  this.timeout(20000);
+
+  describe('to directory', () => {
+    before((done) => {
+      server = helper.start(config, {
+        contentBase: contentBasePublic,
+        https: true
+      }, done);
+      req = request(server.app);
+    });
+
+    it('Request to index', (done) => {
+      req.get('/')
+        .expect(200, /Heyo/, done);
+    });
+  });
+});


### PR DESCRIPTION
Do not use `spdy` on Node 10

`spdy` is effectively unmaintained, and as a consequence of an
implementation that extensively relies on Node’s non-public APIs, broken
on Node 10 and above. In those cases, only https will be used for now.
Once express supports Node's built-in HTTP/2 support, migrating over to
that should be the best way to go.

Fixes: #1449
Fixes: nodejs/node#21665

https://github.com/webpack/webpack-dev-server/commit/e97d345ac370095a6e339b7997b939c88ef3e81b.patch